### PR TITLE
Add schedule customization functionality on App Settings page

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.2.2",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-regular-svg-icons": "^5.15.4",
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/react-fontawesome": "^0.1.15",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/src/components/ScheduleForm.js
+++ b/src/components/ScheduleForm.js
@@ -1,0 +1,238 @@
+import React from "react";
+import moment from "moment";
+import TimeField from "./TimeField";
+import Picker from "./Picker";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrashAlt, faPlusSquare } from "@fortawesome/free-regular-svg-icons";
+import { ISO_FORMAT, toSimple } from "../constants/Date";
+import "../stylesheets/Forms.scss";
+
+const ScheduleField = ({ formName, state = {}, setState, defaultTime = { hours: 7, minutes: 30, isAM: true } }) => {
+  const weekdays = moment.weekdays();
+  const toggleWeekday = (day) => {
+    setState({ ...state, [day]: (state[day] ? null : "default") });
+  };
+  const setDefaultCustom = (e, day) => {
+    if (e.target.value === "default") {
+      setState({ ...state, [day]: "default" });
+    } else {
+      setState({ ...state, [day]: defaultTime });
+    }
+  }
+  const setCustomTime = (value, day) => {
+    setState({ ...state, [day]: value });
+  }
+  return (
+    <form className={"schedule-field"}>
+      <table>
+        <tbody>
+          {weekdays.map((day) => (
+            <tr className={`${state[day] ? "selected" : ""} ${state[day] !== "default" ? "custom" : ""}`} key={day}>
+              <td>
+                <input
+                  className={"weekday-selector"}
+                  type={"button"}
+                  value={day[0].toUpperCase()}
+                  name={day}
+                  onClick={() => toggleWeekday(day)}
+                />
+              </td>
+              <td className={"hide-unselected"}>
+                <Picker
+                  value={state[day] === "default" ? "default" : "custom"}
+                  onChange={(e) => setDefaultCustom(e, day)}
+                >
+                  <option value={"default"}>Use default</option>
+                  <option value={"custom"}>Custom</option>
+                </Picker>
+              </td>
+              <td className={"hide-unselected hide-default"}>
+                <TimeField
+                  formName={formName}
+                  fieldName={day}
+                  setState={(value) => setCustomTime(value, day)}
+                  state={state[day] && state[day] !== "default" ? state[day] : {}}
+                  showError={false}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </form>
+  );
+};
+
+const Holidays = ({ holidays = [], addHoliday, removeHoliday }) => {
+  const [inputState, setInputState] = React.useState("");
+  const [showError, setErrorShown] = React.useState(false);
+
+  const validateDate = (e) => {
+    e.preventDefault();
+    const dateValue = moment(inputState);
+    const isoDate = dateValue.isValid() ? dateValue.format(ISO_FORMAT) : null;
+    if (dateValue.isValid() && dateValue.isSameOrAfter(moment(), "day") && !holidays.includes(isoDate)) {
+      setErrorShown(false);
+      addHoliday(isoDate);
+      setInputState("");
+    } else {
+      setErrorShown(true);
+    }
+  }
+
+  return (
+    <div className={"holidays extra-field"}>
+      <span>Holidays</span>
+      <table className={"holiday-table"}>
+        <tbody>
+          {holidays.length > 0 && holidays.map((date) => (
+            <tr key={date}>
+              <td className={"date"}>{toSimple(date)}</td>
+              <td>
+                <button onClick={() => removeHoliday(date)}>
+                  <FontAwesomeIcon icon={faTrashAlt} />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div>
+        <form className={"inputs-container"} onSubmit={validateDate}>
+          <input
+            type={"date"}
+            placeholder={"Enter a date"}
+            value={inputState}
+            onChange={(e) => setInputState(e.target.value)}
+          />
+          <button type={"submit"}>
+            <FontAwesomeIcon icon={faPlusSquare} />
+          </button>
+        </form>
+        <p className={"error " + (showError ? "shown" : "hidden")}>Please enter a unique, valid date</p>
+      </div>
+    </div>
+  );
+};
+
+export const LunchSchedule = ({ setLunchSchedule, lunchSchedule = {} }) => {
+  const [state, setState] = React.useState(lunchSchedule);
+  const formName = "lunch-schedule";
+  const addHoliday = (date) => {
+    const newHolidays = [...(state.holidays || []), date];
+    newHolidays.sort()
+    setState({
+      ...state,
+      holidays: newHolidays
+    });
+  };
+  const removeHoliday = (date) => {
+    setState({
+      ...state,
+      holidays: (state.holidays || []).filter((holiday) => holiday !== date)
+    });
+  }
+
+  React.useEffect(() => setState(lunchSchedule), [lunchSchedule]);
+
+  return (
+    <div className={"setting-form"}>
+      <h3>Lunch Schedule</h3>
+      <div className={"schedule-form"}>
+        <div className={"extra-fields-container"}>
+          <Holidays holidays={state.holidays} addHoliday={addHoliday} removeHoliday={removeHoliday} />
+          <form className={"extra-field"}>
+            <span>Print Time</span>
+            <TimeField
+              formName={formName}
+              fieldName={"default-time"}
+              setState={(value) => setState({ ...state, defaultTime: value })}
+              state={state.defaultTime}
+              showError={false}
+            />
+          </form>
+        </div>
+        <ScheduleField
+          formName={formName}
+          state={state.schedule}
+          setState={(value) => setState({ ...state, schedule: value })}
+          defaultTime={state.defaultTime}
+        />
+        <div className={"submit-buttons"}>
+          <input
+            type={"button"}
+            className={"styled-button cancel"}
+            value={"Reset"}
+            onClick={() => setState(lunchSchedule)}
+          />
+          <input
+            type={"submit"}
+            className={"styled-button"}
+            value={"Update"}
+            onClick={() => setLunchSchedule(state)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const OrderSchedule = ({ setOrderSchedule, orderSchedule = {} }) => {
+  const [state, setState] = React.useState(orderSchedule);
+  const formName = "order-schedule";
+
+  React.useEffect(() => setState(orderSchedule), [orderSchedule]);
+
+  return (
+    <div className={"setting-form"}>
+      <h3>Order Schedule</h3>
+      <div className={"schedule-form"}>
+        <div className={"extra-fields-container"}>
+          <form className={"extra-field"}>
+            <span>Schedule:</span>
+            <Picker
+              value={state.scheduleType || "DAY_BEFORE"}
+              onChange={(e) => setState({ ...state, scheduleType: e.target.value })}
+            >
+              <option value={"DAY_BEFORE"}>Day before</option>
+              <option value={"DAY_OF"}>Day of</option>
+              <option value={"CUSTOM"}>Custom</option>
+            </Picker>
+          </form>
+          <form className={"extra-field"}>
+            <span>Cutoff Time</span>
+            <TimeField
+              formName={formName}
+              fieldName={"default-time"}
+              setState={(value) => setState({ ...state, defaultTime: value })}
+              state={state.defaultTime}
+              showError={false}
+            />
+          </form>
+        </div>
+        {state.scheduleType === "CUSTOM" && (
+          <ScheduleField
+            formName={formName}
+            state={state.schedule}
+            setState={(value) => setState({ ...state, schedule: value })}
+            defaultTime={state.defaultTime}
+          />
+        )}
+        <div className={"submit-buttons"}>
+          <input
+            type={"button"}
+            className={"styled-button cancel"}
+            value={"Reset"}
+            onClick={() => setState(orderSchedule)}
+          />
+          <input
+            type={"submit"}
+            className={"styled-button"}
+            value={"Update"}
+            onClick={() => setOrderSchedule(state)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TimeField.js
+++ b/src/components/TimeField.js
@@ -1,0 +1,44 @@
+import React from "react";
+import Picker from "./Picker";
+
+const TimeField = ({ formName, fieldName, state = {}, setState, showError }) => {
+  const setHours = (e) => setState({ ...state, hours: parseInt(e.target.value) });
+  const setMinutes = (e) => setState({ ...state, minutes: parseInt(e.target.value) });
+  const setAMPM = (e) => setState({...state, isAM: e.target.value === "am"});
+  return (
+    <div className={"time-field"}>
+      <div>
+        <label>
+          <span>Hours</span>
+          <input
+            type={"number"}
+            placeholder={"Hour"}
+            id={`${formName}-${fieldName}-hour`}
+            name={"hour"}
+            value={isNaN(state.hours) ? "" : state.hours}
+            onChange={setHours}
+          />
+        </label>
+        <p>:</p>
+        <label>
+          <span>Minutes</span>
+          <input
+            type={"number"}
+            placeholder={"Minute"}
+            id={`${formName}-${fieldName}-minute`}
+            name={"minute"}
+            value={(!isNaN(state.minutes) && state.minutes < 10 ? "0" : "") + state.minutes}
+            onChange={setMinutes}
+          />
+        </label>
+        <Picker name={"amPM"} id={`${formName}-${fieldName}-amPM`} value={state.isAM ? "am" : "pm"} onChange={setAMPM}>
+          <option value={"am"}>AM</option>
+          <option value={"pm"}>PM</option>
+        </Picker>
+      </div>
+      <p className={"error " + (showError ? "shown" : "hidden")}>Please enter a valid time</p>
+    </div>
+  )
+};
+
+export default TimeField

--- a/src/constants/Date.js
+++ b/src/constants/Date.js
@@ -2,8 +2,38 @@ import moment from "moment";
 
 export const ISO_FORMAT = "YYYY-MM-DD";
 export const READABLE_FORMAT = "dddd, MMMM Do";
+export const SIMPLE_FORMAT = "M/DD/YYYY";
 
 export const parseISO = (date) => moment(date, ISO_FORMAT);
 export const parseReadable = (date) => moment(date, READABLE_FORMAT)
 export const toISO = (date) => parseReadable(date).format(ISO_FORMAT);
 export const toReadable = (date) => parseISO(date).format(READABLE_FORMAT);
+export const toSimple = (date) => parseISO(date).format(SIMPLE_FORMAT);
+
+export function firebaseTimeToStateTime(time) {
+  if (!time || time === {}) {
+    return {};
+  }
+  let { hours, minutes } = time;
+  let isAM = hours < 12;
+  if (hours === 0) {
+    hours = 12;
+  } else if (!isAM) {
+    hours -= 12;
+  }
+  return { hours, minutes, isAM };
+}
+
+export function stateTimeToFirebaseTime(time) {
+  if (!time || time === {}) {
+    return {};
+  }
+  let { hours, minutes, isAM } = time;
+  if (hours === 12) {
+    hours -= 12;
+  }
+  if (!isAM) {
+    hours += 12;
+  }
+  return { hours, minutes };
+}

--- a/src/redux/Actions.js
+++ b/src/redux/Actions.js
@@ -56,7 +56,6 @@ function updateAppSettings(appSettings) {
   return {
     type: Actions.UPDATE_APP_SETTINGS,
     appSettings: {
-      cutoffTime: appSettings.cutoffTime || { hours: 0, minutes: 0 },
       defaultUser: appSettings.defaultUser || {},
       orderOptions: appSettings.orderOptions || [],
       userFields: appSettings.userFields || [],
@@ -180,15 +179,6 @@ export function resetPasswords(uids, dispatch) {
     console.log(`Failed to reset ${failed.length} passwords.`);
     dispatch(setLoading(false));
   }).catch((error) => reportError(error, dispatch));
-}
-
-export function setCutoffTime(time, dispatch, domain) {
-  dispatch(setLoading(true));
-  domainData(domain).collection("appData").doc("cutoffTime").set(time)
-    .then(() => {
-      console.log("Successfully updated cutoff time");
-      dispatch(setLoading(false));
-    }).catch((error) => reportError(error, dispatch));
 }
 
 export function setOrderOptions(newOptions, dispatch, domain) {

--- a/src/redux/Actions.js
+++ b/src/redux/Actions.js
@@ -10,7 +10,7 @@ import {
   updateDomainData,
   importUsersFunction
 } from "../constants/Firebase";
-import { parseISO } from "../constants/Date";
+import { ISO_FORMAT, parseISO, firebaseTimeToStateTime, stateTimeToFirebaseTime } from "../constants/Date";
 import moment from "moment";
 
 const Actions = {
@@ -59,7 +59,9 @@ function updateAppSettings(appSettings) {
       cutoffTime: appSettings.cutoffTime || { hours: 0, minutes: 0 },
       defaultUser: appSettings.defaultUser || {},
       orderOptions: appSettings.orderOptions || [],
-      userFields: appSettings.userFields || []
+      userFields: appSettings.userFields || [],
+      lunchSchedule: appSettings.lunchSchedule || {},
+      orderSchedule: appSettings.orderSchedule || {}
     }
   }
 }
@@ -225,6 +227,26 @@ export function setDefaultUser(data, dispatch, domain) {
     }).catch((error) => reportError(error, dispatch));
 }
 
+export function setLunchSchedule(data, dispatch, domain) {
+  dispatch(setLoading(true));
+  let dataToPush = { ...data, defaultTime: stateTimeToFirebaseTime(data.defaultTime) }
+  domainData(domain).collection("appData").doc("lunchSchedule").set(dataToPush)
+    .then(() => {
+      console.log("Successfully updated lunch schedule data");
+      dispatch(setLoading(false));
+    }).catch((error) => reportError(error, dispatch));
+}
+
+export function setOrderSchedule(data, dispatch, domain) {
+  dispatch(setLoading(true));
+  let dataToPush = { ...data, defaultTime: stateTimeToFirebaseTime(data.defaultTime) }
+  domainData(domain).collection("appData").doc("orderSchedule").set(dataToPush)
+    .then(() => {
+      console.log("Successfully updated order schedule data");
+      dispatch(setLoading(false));
+    }).catch((error) => reportError(error.dispatch));
+}
+
 export async function importUsers(data, dispatch) {
   dispatch(setLoading(true));
   let userData = {};
@@ -247,19 +269,12 @@ export async function importUsers(data, dispatch) {
 export function orderListener(dispatch, isLoggedIn, domain) {
   if (!isLoggedIn) return;
   return domainData(domain).collection("orders")
+    .where("date", ">=", moment().format(ISO_FORMAT))
     .onSnapshot((querySnapshot) => {
-      let orders = [];
-      querySnapshot.forEach((doc) => {
-        let data = doc.data();
-        // Filter out all orders before today
-        if (!parseISO(data.date).isBefore(moment(), "day")) {
-          orders.push({
-            ...doc.data(),
-            key: doc.id
-          });
-        }
-      });
-      dispatch(updateOrders(orders));
+      dispatch(updateOrders(querySnapshot.docs.map((doc) => ({
+        ...doc.data(),
+        key: doc.id
+      }))));
     });
 }
 
@@ -299,11 +314,36 @@ export function appSettingsListener(dispatch, isLoggedIn, domain) {
     .onSnapshot((querySnapshot) => {
       dispatch(setLoading(true));
       let appSettings = {};
+      let data;
       querySnapshot.forEach((doc) => {
-        if (doc.id === "cutoffTime" || doc.id === "defaultUser") {
-          appSettings[doc.id] = doc.data();
-        } else {
-          appSettings[doc.id] = Object.values(doc.data());
+        switch (doc.id) {
+          case "cutoffTime":
+          case "defaultUser":
+            appSettings[doc.id] = doc.data();
+            break;
+          case "orderSchedule":
+            data = doc.data() || {};
+            appSettings[doc.id] = {
+              ...data,
+              defaultTime: firebaseTimeToStateTime(data.defaultTime)
+            };
+            break;
+          // Filter out holidays before today
+          case "lunchSchedule":
+            data = doc.data() || {};
+            appSettings[doc.id] = {
+              ...data,
+              defaultTime: firebaseTimeToStateTime(data.defaultTime),
+              holidays: (data.holidays || []).filter((date) => parseISO(date).isSameOrAfter(moment(), "day"))
+            };
+            break;
+          // Order options/user fields are stored as objects with the index as keys
+          case "orderOptions":
+          case "userFields":
+            appSettings[doc.id] = Object.values(doc.data());
+            break;
+          default:
+            break;
         }
       });
       dispatch(updateAppSettings(appSettings));

--- a/src/screens/AppSettings.js
+++ b/src/screens/AppSettings.js
@@ -8,7 +8,6 @@ import SettingsForm from "../components/SettingsForm";
 import StyledButton from "../components/StyledButton";
 import { LunchSchedule, OrderSchedule } from "../components/ScheduleForm";
 import {
-  setCutoffTime,
   setUserFields,
   setOrderOptions,
   setDomainData,
@@ -18,20 +17,6 @@ import {
 } from "../redux/Actions";
 import "../stylesheets/AppSettings.scss";
 import Loading from "./Loading";
-
-function toStateFormat(cutoffTime) {
-  if (!cutoffTime || cutoffTime === {}) {
-    return {};
-  }
-  let { hours, minutes } = cutoffTime;
-  let isAM = hours < 12;
-  if (hours === 0) {
-    hours = 12;
-  } else if (!isAM) {
-    hours -= 12;
-  }
-  return { hours, minutes, isAM };
-}
 
 const DomainForm = ({ domain, setDomainData }) => (
   <SettingsForm
@@ -147,7 +132,7 @@ const UserFieldsTable = ({ userFields, setUserFields }) => {
   );
 };
 
-const AppSettings = ({ navbarHeight, appSettings, domain, setCutoffTime, setOrderOptions, setUserFields, setDomainData, setDefaultUser, setLunchSchedule, setOrderSchedule }) => (
+const AppSettings = ({ navbarHeight, appSettings, domain, setOrderOptions, setUserFields, setDomainData, setDefaultUser, setLunchSchedule, setOrderSchedule }) => (
   !appSettings ?
     <Loading /> :
     <div id={"Orders"} className={"content-container"} style={{ height: "calc(100vh - " + navbarHeight + "px)" }}>
@@ -166,7 +151,6 @@ const mapStateToProps = ({ appSettings, domain }) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  setCutoffTime: (time, domain) => setCutoffTime(time, dispatch, domain),
   setOrderOptions: (newOptions, domain) => setOrderOptions(newOptions, dispatch, domain),
   setUserFields: (newFields, domain) => setUserFields(newFields, dispatch, domain),
   setDomainData: (data, domainId) => setDomainData(data, dispatch, domainId),

--- a/src/screens/AppSettings.js
+++ b/src/screens/AppSettings.js
@@ -6,8 +6,16 @@ import { OrderOptionColumns, UserFieldColumns, PasswordField } from "../constant
 import DomainFields from "../constants/DomainFields";
 import SettingsForm from "../components/SettingsForm";
 import StyledButton from "../components/StyledButton";
-import { setCutoffTime, setUserFields, setOrderOptions, setDomainData, setDefaultUser } from "../redux/Actions";
-import Picker from "../components/Picker";
+import { LunchSchedule, OrderSchedule } from "../components/ScheduleForm";
+import {
+  setCutoffTime,
+  setUserFields,
+  setOrderOptions,
+  setDomainData,
+  setDefaultUser,
+  setLunchSchedule,
+  setOrderSchedule
+} from "../redux/Actions";
 import "../stylesheets/AppSettings.scss";
 import Loading from "./Loading";
 
@@ -38,87 +46,16 @@ const DomainForm = ({ domain, setDomainData }) => (
 const DefaultUserForm = ({ userFields, defaultUser, setDefaultUser }) => {
   const processedFields = userFields.map((field) => ({ ...field, type: field.inputType, required: false }));
   return (
-  <SettingsForm
-    data={defaultUser}
-    onSubmit={setDefaultUser}
-    title={"Default User"}
-    fields={[PasswordField, ...processedFields]}
-    id={"default-user-form"}
-    checkRequired={false}
-  />
-)
-}
-
-const CutoffTime = ({ cutoffTime, setCutoffTime }) => {
-  const [showError, toggleError] = React.useState(false);
-  const [state, setState] = React.useState(toStateFormat(cutoffTime));
-
-  const submit = (e) => {
-    e.preventDefault();
-    let { hours, minutes, isAM } = state;
-    if (isNaN(hours) || isNaN(minutes) || hours < 1 || hours > 12 || minutes < 0 || minutes > 59) {
-      toggleError(true);
-      return;
-    }
-    toggleError(false);
-    if (isAM && hours === 12) {
-      hours = 0;
-    } else if (!isAM && hours !== 12) {
-      hours += 12;
-    }
-    setCutoffTime({ hours, minutes });
-  };
-  const setHours = (e) => {
-    setState({ ...state, hours: parseInt(e.target.value) });
-  };
-  const setMinutes = (e) => {
-    setState({ ...state, minutes: parseInt(e.target.value) });
-  };
-  const setAMPM = (e) => {
-    setState({...state, isAM: e.target.value === "am"});
-  };
-
-  React.useEffect(() => setState(toStateFormat(cutoffTime)), [cutoffTime]);
-
-  return (
-    <div className={"cutoff-time single-row-setting"}>
-      <h3 className={"title"}>Cutoff Time</h3>
-      <div className={"form-wrapper"}>
-        <form onSubmit={submit}>
-          <label>
-            <span>Hours</span>
-            <input
-              type={"number"}
-              placeholder={"Hour"}
-              id={"hour"}
-              name={"hour"}
-              value={isNaN(state.hours) ? "" : state.hours}
-              onChange={setHours}
-            />
-          </label>
-          <p>:</p>
-          <label>
-            <span>Minutes</span>
-            <input
-              type={"number"}
-              placeholder={"Minute"}
-              id={"minute"}
-              name={"minute"}
-              value={(!isNaN(state.minutes) && state.minutes < 10 ? "0" : "") + state.minutes}
-              onChange={setMinutes}
-            />
-          </label>
-          <Picker name={"amPM"} id={"amPM"} value={state.isAM ? "am" : "pm"} onChange={setAMPM}>
-            <option value={"am"}>AM</option>
-            <option value={"pm"}>PM</option>
-          </Picker>
-          <input className={"styled-button"} type={"submit"} value={"Update"} disabled={state === toStateFormat(cutoffTime)} />
-        </form>
-        <p className={"error " + (showError ? "shown" : "hidden")}>Please enter a valid time</p>
-      </div>
-    </div>
+    <SettingsForm
+      data={defaultUser}
+      onSubmit={setDefaultUser}
+      title={"Default User"}
+      fields={[PasswordField, ...processedFields]}
+      id={"default-user-form"}
+      checkRequired={false}
+    />
   )
-}
+};
 
 const OrderOptionsTable = ({ orderOptions, setOrderOptions }) => {
   const editOrderOption = (index, editedOption) => {
@@ -210,13 +147,14 @@ const UserFieldsTable = ({ userFields, setUserFields }) => {
   );
 };
 
-const AppSettings = ({ navbarHeight, appSettings, domain, setCutoffTime, setOrderOptions, setUserFields, setDomainData, setDefaultUser }) => (
+const AppSettings = ({ navbarHeight, appSettings, domain, setCutoffTime, setOrderOptions, setUserFields, setDomainData, setDefaultUser, setLunchSchedule, setOrderSchedule }) => (
   !appSettings ?
     <Loading /> :
     <div id={"Orders"} className={"content-container"} style={{ height: "calc(100vh - " + navbarHeight + "px)" }}>
       <DomainForm domain={domain} setDomainData={(data) => setDomainData(data, domain.id)} />
       <DefaultUserForm defaultUser={appSettings.defaultUser} userFields={appSettings.userFields} setDefaultUser={(data) => setDefaultUser(data, domain.id)} />
-      <CutoffTime cutoffTime={appSettings.cutoffTime} setCutoffTime={(time) => setCutoffTime(time, domain.id)} />
+      <LunchSchedule lunchSchedule={appSettings.lunchSchedule} setLunchSchedule={(data) => setLunchSchedule(data, domain.id)} />
+      <OrderSchedule orderSchedule={appSettings.orderSchedule} setOrderSchedule={(data) => setOrderSchedule(data, domain.id)} />
       <OrderOptionsTable orderOptions={appSettings.orderOptions} setOrderOptions={(newOptions) => setOrderOptions(newOptions, domain.id)} />
       <UserFieldsTable userFields={appSettings.userFields} setUserFields={(newFields) => setUserFields(newFields, domain.id)} />
     </div>
@@ -232,7 +170,9 @@ const mapDispatchToProps = (dispatch) => ({
   setOrderOptions: (newOptions, domain) => setOrderOptions(newOptions, dispatch, domain),
   setUserFields: (newFields, domain) => setUserFields(newFields, dispatch, domain),
   setDomainData: (data, domainId) => setDomainData(data, dispatch, domainId),
-  setDefaultUser: (data, domain) => setDefaultUser(data, dispatch, domain)
+  setDefaultUser: (data, domain) => setDefaultUser(data, dispatch, domain),
+  setLunchSchedule: (data, domain) => setLunchSchedule(data, dispatch, domain),
+  setOrderSchedule: (data, domain) => setOrderSchedule(data, dispatch, domain)
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(AppSettings);

--- a/src/stylesheets/Forms.scss
+++ b/src/stylesheets/Forms.scss
@@ -1,4 +1,5 @@
 @use "index";
+@use "sass:color";
 
 form {
   input:not([type=button]):not([type=submit]):not([type=checkbox]), select {
@@ -30,6 +31,7 @@ form {
       -moz-appearance:none;
       appearance:none;
       position: relative;
+      padding-right: 35px;
     }
     .caret {
       pointer-events: none;
@@ -44,6 +46,25 @@ form {
       border-top: 5px solid #000;
       border-right: 5px solid transparent;
       border-left: 5px solid transparent;
+    }
+  }
+  .time-field > div {
+    flex-direction: row;
+    align-items: stretch;
+    & > * {
+      margin: 0 5px;
+    }
+    label > span {
+      display: none;
+    }
+    p {
+      justify-content: center;
+      font-weight: bold;
+      font-size: 24px;
+    }
+    select {
+      padding-right: 40px;
+      width: fit-content;
     }
   }
 }
@@ -144,6 +165,142 @@ form {
     .checkbox {
       margin-right: 10px;
       flex: 0;
+    }
+  }
+}
+
+.schedule-field {
+  margin: 0 !important;
+  table {
+    box-shadow: none;
+  }
+  tr {
+    background-color: transparent !important;
+    align-items: flex-start;
+    .weekday-selector {
+      border: none;
+      background-color: index.$textInputColor;
+      width: 50px;
+      height: 50px;
+      align-items: center;
+      justify-content: center;
+      border-radius: 1000px;
+      cursor: pointer;
+      font-size: 18px;
+      &:hover {
+        background-color: color.adjust(index.$textInputColor, $lightness: -10%);
+      }
+    }
+    select {
+      width: fit-content;
+    }
+    .hide-unselected, .hide-default {
+      visibility: hidden;
+    }
+    &.selected {
+      .weekday-selector {
+        background-color: index.$lightAccentColor;
+        &:hover {
+          background-color: color.adjust(index.$lightAccentColor, $alpha: -0.3);
+        }
+      }
+      .hide-unselected {
+        visibility: visible;
+        &.hide-default {
+          visibility: hidden;
+        }
+      }
+      &.custom .hide-default {
+        visibility: visible;
+      }
+    }
+  }
+}
+
+.schedule-form {
+  form span, .holidays span {
+    font-weight: bold;
+    padding: 10px;
+  }
+
+  .extra-fields-container {
+    flex-direction: row;
+
+    .extra-field {
+      margin: 20px 20px 20px 0;
+    }
+  }
+
+  .submit-buttons {
+    flex-direction: row;
+    justify-content: flex-end;
+    input {
+      padding: 12px;
+      margin-left: 10px;
+      &.cancel {
+        background-color: transparent;
+        border: 1px index.$checkboxText solid !important;
+        color: index.$checkboxText !important;
+
+        &:hover {
+          opacity: 0.8;
+        }
+      }
+    }
+  }
+
+  .holidays {
+    button {
+      padding: 10px;
+      cursor: pointer;
+      border-radius: 3px;
+      background-color: index.$textInputColor;
+      font-size: 20px;
+      align-items: center;
+      justify-content: center;
+      &:hover {
+        background-color: color.adjust(index.$textInputColor, $lightness: -10%);
+      }
+      &[type=submit] {
+        margin-left: 20px;
+        background-color: index.$accentColor;
+        &:hover {
+          background-color: index.$darkAccentColor;
+        }
+      }
+    }
+
+    .holiday-table {
+      box-shadow: none;
+      margin: 0;
+
+      tr {
+        background-color: transparent;
+      }
+
+      td {
+        padding: 10px;
+
+        &.date {
+          flex: 1;
+          text-align: left;
+          align-items: flex-start;
+        }
+      }
+    }
+
+    .error {
+      margin-left: 10px;
+    }
+
+    .inputs-container {
+      flex-direction: row;
+      margin: 10px 0;
+      padding: 10px;
+
+      input[type=text] {
+        width: unset;
+      }
     }
   }
 }

--- a/src/stylesheets/Home.scss
+++ b/src/stylesheets/Home.scss
@@ -1,5 +1,4 @@
 @use "index";
-@use "sass:color";
 
 $contentContainerPadding: 20px;
 
@@ -57,7 +56,7 @@ nav {
         right: 0;
         height: 100%;
         width: 100%;
-        background-color: color.adjust(index.$accentColor, $lightness: 15%);
+        background-color: index.$lightAccentColor;
         border-right: 10px solid index.$accentColor;
         border-top-left-radius: 100px;
         border-bottom-left-radius: 100px;

--- a/src/stylesheets/index.scss
+++ b/src/stylesheets/index.scss
@@ -2,6 +2,7 @@
 
 $accentColor: #ffd541;
 $darkAccentColor: color.adjust($accentColor, $saturation: -20%);
+$lightAccentColor: color.adjust($accentColor, $lightness: 15%);
 $backgroundColor: #fff;
 $textInputColor: #f0f0f0;
 $primaryText: #000;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,6 +1372,39 @@
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.3.0.tgz#d1689566b94c25423d1fb2cb031c5c2ea4c9f939"
   integrity sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ==
 
+"@fortawesome/fontawesome-common-types@^0.2.36":
+  version "0.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
+  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+
+"@fortawesome/fontawesome-svg-core@^1.2.36":
+  version "1.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz#4f2ea6f778298e0c47c6524ce2e7fd58eb6930e3"
+  integrity sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/free-regular-svg-icons@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz#b97edab436954333bbeac09cfc40c6a951081a02"
+  integrity sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/free-solid-svg-icons@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
+  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/react-fontawesome@^0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.15.tgz#1450b838f905981d721bf07e14e3b52c0e9a91ed"
+  integrity sha512-/HFHdcoLESxxMkqZAcZ6RXDJ69pVApwdwRos/B2kiMWxDSAX2dFK8Er2/+rG+RsrzWB/dsAyjefLmemgmfE18g==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@google-cloud/paginator@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@google-cloud/paginator/-/paginator-2.0.3.tgz#c7987ad05d1c3ebcef554381be80e9e8da4e4882"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,9 +3516,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001173:
-  version "1.0.30001179"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz#b0803883b4471a6c62066fb1752756f8afc699c8"
-  integrity sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
+  version "1.0.30001251"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz"
+  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Lunch Schedule panel
  - Admin can set which days users can order lunches for
  - Admin can set default print time and customize time for each lunch day
  - Admin can add holidays (specific dates when users cannot order lunch)
- Order Schedule panel
  - Admin can select type of ordering schedule
    - Day before: user can place orders until the day before
    - Day of: users can place orders until the day of
    - Custom: users can place orders until specific dates (ex: for weekly ordering)
  - Admin can set a cutoff ordering time
  - (For custom schedule type) admin can create custom ordering schedule
- Remove cutoff time single-field panel

Resolves: #20